### PR TITLE
Vagrantfile - config.vm.box = "bento/ubuntu-14.04"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure("2") do |config|
   config.vm.define :gitlab do |config|
     # Configure some hostname here
     # config.vm.hostname = "gitlab.invalid"
-    config.vm.box = "chef/ubuntu-14.04"
+    config.vm.box = "bento/ubuntu-14.04"
     config.vm.provision :shell, :path => "install-gitlab.sh"
 
     # On Linux, we cannot forward ports <1024


### PR DESCRIPTION
This fixes the following error on `vagrant up`:

    Bringing machine 'gitlab' up with 'virtualbox' provider...
    ==> gitlab: Box 'chef/ubuntu-14.04' could not be found. Attempting to find and install...
        gitlab: Box Provider: virtualbox
        gitlab: Box Version: >= 0
    ==> gitlab: Loading metadata for box 'chef/ubuntu-14.04'
        gitlab: URL: https://atlas.hashicorp.com/chef/ubuntu-14.04
    The box you're adding has a name different from the name you
    requested. For boxes with metadata, you cannot override the name.
    If you're adding a box using `vagrant box add`, don't specify
    the `--name` parameter. If the box is being added via a Vagrantfile,
    change the `config.vm.box` value to match the name below.

    Requested name: chef/ubuntu-14.04
    Actual name: bento/ubuntu-14.04