### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Supported Vagrant providers:
 Untested Vagrant providers (worked with 14.04 LTS):
  * VMWare
 
+Requires Vagrant >= 1.8.0.
 
 Usage
 =====


### PR DESCRIPTION
Vagrant > 1.8.0 required, because the `env` command doesn't exist in Vagrant < 1.8.0.