### PR TITLE
Change vagrant box to bento/ubuntu-16.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Configuration
 
 You can configure the VM running Gitlab by exporting environment variables on host side before issuing `vagrant up`:
  * `GITLAB_CPUS` = how many CPUs will be given to the VM (default `2`)
- * `GITLAB_MEMORY` = how much memory (in MB) will be used (default `2048`)
+ * `GITLAB_MEMORY` = how much memory (in MB) will be used (default `3072`)
  * `GITLAB_PORT` = which port on the host Gitlab responds to (default `8443`)
  * `GITLAB_SWAP` = if you want a swap file within VM (low memory host), in G (default `0`)
  * `GITLAB_HOST` = set hostname (default is `gitlab.local`)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 
 # read configurable cpu/memory/port/swap/host/edition settings from environment variables
 memory = ENV['GITLAB_MEMORY'] || 3072
-cpus = ENV['GITLAB_CPUS'] || 1
+cpus = ENV['GITLAB_CPUS'] || 2
 port = ENV['GITLAB_PORT'] || 8443
 swap = ENV['GITLAB_SWAP'] || 0
 host = ENV['GITLAB_HOST'] || "gitlab.local"

--- a/install-gitlab.sh
+++ b/install-gitlab.sh
@@ -100,8 +100,9 @@ check_for_backwards_compatibility
 # install swap file for more memory
 install_swap_file
 
-# install tools to automate this install
+# install tools to automate this install and apply updates
 apt-get -y update
+apt-get -y upgrade
 apt-get -y install debconf-utils curl
 
 # install the few dependencies we have

--- a/install-gitlab.sh
+++ b/install-gitlab.sh
@@ -100,9 +100,8 @@ check_for_backwards_compatibility
 # install swap file for more memory
 install_swap_file
 
-# install tools to automate this install and apply updates
+# install tools to automate this install
 apt-get -y update
-apt-get -y upgrade
 apt-get -y install debconf-utils curl
 
 # install the few dependencies we have


### PR DESCRIPTION
Related to Issue #16 

I have created a modification using the vagrant box "bento/ubuntu-16.04" which supports virtualbox, vmware (fusion and workstation) and parallels providers. (see https://github.com/agiletechnologist/gitlab-installer to clone for testing). I have tested 2 of 6 tested. LXC did not change.

### Changes

- Vagrantfile - Changed default box to "bento/ubuntu-16.04"
- Vagrantfile - Changed vmware_fusion to be vmware_desktop which will work with both vmware_fusion and vmware_workstation providers and removed override of the box for vmware_desktop
- Vagrantfile - fixed default for GITLAB_CPUS to match Documentation default of 2
- README.md - for new minimum memory default for GITLAB_MEMORY of 3072
- install-gitlab.sh - Added apt-get upgrade before installation to apply updates and security updates before installing.