### PR TITLE
Add option GITLAB_PRIVATE_NETWORK to enable a private_network

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You can configure the VM running Gitlab by exporting environment variables on ho
  * `GITLAB_SWAP` = if you want a swap file within VM (low memory host), in G (default `0`)
  * `GITLAB_HOST` = set hostname (default is `gitlab.local`)
  * `GITLAB_EDITION` = set GitLab edition which you would like to use. (default is `community`; options are `community` or `enterprise`)
+ * `GITLAB_PRIVATE_NETWORK` = add a private network interface
 
 Example:
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,7 @@ port = ENV['GITLAB_PORT'] || 8443
 swap = ENV['GITLAB_SWAP'] || 0
 host = ENV['GITLAB_HOST'] || "gitlab.local"
 edition = ENV['GITLAB_EDITION'] || "community"
+private_network = ENV['GITLAB_PRIVATE_NETWORK'] || 0
 
 Vagrant.require_version ">= 1.8.0"
 
@@ -27,6 +28,7 @@ Vagrant.configure("2") do |config|
     # or access the site via hostname:<port>, in this case 127.0.0.1:8080
     # By default, Gitlab is at https + port 8443
     config.vm.network :forwarded_port, guest: 443, host: port
+    config.vm.network "private_network", type: "dhcp" if private_network == '1'
 
     # use rsync for synced folder to avoid the need for provider tools
 	# added rsync__auto  to enable detect changes on host and sync to guest machine and exclude .git/


### PR DESCRIPTION
By setting GITLAB_PRIVATE_NETWORK=1 a private_network interface
will be added to the virtual machine.